### PR TITLE
Switch main apache user back to 'root'

### DIFF
--- a/conf/default.yml
+++ b/conf/default.yml
@@ -6,12 +6,7 @@ services:
     environment:
       APACHE_RUN_USER: www-data
       APACHE_RUN_GROUP: www-data
-      APACHE_PORT: 8080
-    expose:
-      - 8080
-    labels:
-      - traefik.port=8080
-    user: www-data
+      APACHE_PORT: 80
     read_only: true
     tmpfs:
       - /var/run
@@ -19,6 +14,10 @@ services:
       - /tmp
     cap_drop:
       - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+      - NET_BIND_SERVICE
     
 networks:
   default:


### PR DESCRIPTION
…while still having APACHE_RUN_USER set to www-data

This ensures that any webscript cannot signal the main thread, thus interfering with the container itself
Going back to root as main user, allows for APACHE_PORT to be 80 again
Apache now requires capabilities SETUID, SETGID and NET_BIND_SERVICE