### PR TITLE
Alle containere på ét netværk

### DIFF
--- a/bin/new-tenant.sh
+++ b/bin/new-tenant.sh
@@ -17,6 +17,9 @@ SHARED_UID=65534
 # GID to use for ftp-users (nogroup)
 SHARED_GID=65534
 
+# Hotel Network CIDR in mysql wildcard format % = match all
+HOTEL_NETWORK="172.19.%"
+
 # TODO:
 # - Trap errors?
 # - Create apache/docker configuration?
@@ -61,7 +64,7 @@ fi;
 
 # Create mysql database
 $MYSQL_CMD -e "CREATE DATABASE ${T_DB_NAME}"
-$MYSQL_CMD -e "GRANT ALL PRIVILEGES ON ${T_DB_NAME}.* to ${T_USERNAME} identified by '${T_DB_PASSWORD}'"
+$MYSQL_CMD -e "GRANT ALL PRIVILEGES ON ${T_DB_NAME}.* to '${T_USERNAME}'@'${HOTEL_NETWORK}' identified by '${T_DB_PASSWORD}'"
 
 # Create ftp user
 $MYSQL_CMD ${MYSQL_PROFTPD_DB} -e "INSERT INTO users (userid, passwd, uid, gid, homedir) VALUES ('${T_USERNAME}', '${T_PASSWORD_CRYPT}', ${SHARED_UID}, ${SHARED_GID}, '${T_HOMEDIR}')"

--- a/conf/default.yml
+++ b/conf/default.yml
@@ -24,8 +24,9 @@ services:
       - NET_RAW
     extra_hosts:
      - "db:62.243.225.163"
+    networks:
+     - hotel
     
 networks:
-  default:
-    external:
-      name: hotel
+  hotel:
+    external: true


### PR DESCRIPTION
> - Let 'hotel'-network be the only network attached to guest containers
> - Updated new-tenant.sh to let hotel-network CIDR be part of mysql GRANT-command
> - fixes #12 

Hotel-netværket på mysa = 172.19.0.0/16, og alle apache containere kommer nu på det og _kun_ dét.
Det betyder så, at vi kan lave alle brugere i mysql med host-permission = "172.19.%".